### PR TITLE
Enable customized font's in Nebula CWT controls (VControl) for CDateTime

### DIFF
--- a/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/v/VControl.java
+++ b/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/v/VControl.java
@@ -115,6 +115,10 @@ public abstract class VControl {
 	Color fill;
 	Color foreground;
 	Color background;
+	/**
+	 * allow for customised fonts
+	 */
+	Font font;
 	private Cursor activeCursor;
 	private Cursor inactiveCursor;
 
@@ -435,7 +439,13 @@ public abstract class VControl {
 	public boolean getEnabled() {
 		return hasState(STATE_ENABLED);
 	}
-
+	/**
+	 * Getter for the control's font
+	 * @return
+	 */
+	public Font getFont() {
+		return font;
+	}
 	public Color getForeground() {
 		return foreground;
 	}
@@ -794,7 +804,8 @@ public abstract class VControl {
 	}
 
 	public void setFont(Font font) {
-		// TODO setFont
+		// 
+		this.font = font;
 	}
 
 	public void setForeground(Color color) {

--- a/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/v/VControlPainter.java
+++ b/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/v/VControlPainter.java
@@ -12,6 +12,7 @@
 package org.eclipse.nebula.cwt.v;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Event;
@@ -167,14 +168,18 @@ public class VControlPainter implements IControlPainter {
 	}
 	
 	private static void paintText(VControl control, Event e) {
+		Font current = control.font;
 		e.gc.setTextAntialias(SWT.ON);
 
 		if(control.foreground != null && !control.foreground.isDisposed()) {
 			e.gc.setForeground(control.foreground);
 		}
-
+		if (control.font != null && !control.font.isDisposed() ) {
+			e.gc.setFont(control.font);
+		}
 		Point size = e.gc.textExtent(control.text);
 		e.gc.drawText(control.text, (int)getX(control, size.x), (int)getY(control, size.y), true);
+		e.gc.setFont(current);
 	}
 
 	public void dispose() {


### PR DESCRIPTION
The CDateTime widget lacks the possibility to customize the font style (bold, italic) for the distinct day labels.

In VControl.java the method "setFont" is not yet implemented and there is no member variable holding the instance of the font.

However the proposed changes allow setting the font (via existing VControl.setFont(Font f)) and using this font when painting the text of the control. 